### PR TITLE
#369 resolved

### DIFF
--- a/gameFunctions.py
+++ b/gameFunctions.py
@@ -390,7 +390,9 @@ def updateItems(setting, screen, stats, sb, ship, aliens, bullets, eBullets, ite
         if item.rect.bottom <= 0:
             items.remove(item)
     for item in items.sprites():
-        if item.rect.centerx -30 < ship.rect.x < item.rect.x +30 and item.rect.centery -20 < ship.rect.centery < item.rect.centery +20:
+        disX = int((ship.rect.centerx - ship.rect.x) + (item.rect.centerx - item.rect.x)*0.67)
+        disY = int((ship.rect.centery - ship.rect.y) + (item.rect.centery - item.rect.y)*0.67)
+        if abs(item.rect.centerx - ship.rect.centerx) < disX and abs(item.rect.centery-ship.rect.centery) < disY:
             if item.type == 1:
                 if stats.shipsLeft < setting.shipLimit:
                     stats.shipsLeft += 1


### PR DESCRIPTION
하트의 픽셀에 맞춰져 있던 기존의 코드는 아이템 크기가 하트와 다르면 판정에 문제가 생길 수 있다는 것을 발견했습니다.
즉, 아이템의 크기를 모두 똑같이 맞춘 후 코드에 크기의 픽셀을 입력하는 방법이 있겠지만, 게임 아이템의 다양성을 키우기 위해 아이템의 크기를 다르게 만들고 싶을 경우를 대비. 아이템 이미지와 내 기체 좌표와 각각의 이미지 크기를 이용하여 문제를 해결하는 것이 더 낫다는 판단을 하게 되었습니다.(변수를 두개를 더 선언하고 계산과정이 추가 하였지만, 계산 과정의 복잡도가 크지 않아 코드에 무리가 가지 않습니다)

결과적으로 내기체의 이미지가 아이템 이미지의 가로 세로 1/6지점 이상을 덮게 되면, 아이템을 섭취하게 코드를 작성 하였고 게임 내에서 아이템을 섭취하는 과정의 애니메이션의 판정이 큰 오차가 발생하지 않습니다.