### PR TITLE
Boss's moving to down is removed.

### DIFF
--- a/gameFunctions.py
+++ b/gameFunctions.py
@@ -301,11 +301,6 @@ def changeFleetDir(setting, aliens):
                 alien.rect.y += setting.fleetDropSpeed
             elif setting.gameLevel == 'hard':
                 alien.rect.y += (setting.fleetDropSpeed + 3)
-        else:
-            if alien.rect.y < int(setting.screenHeight * 0.8):
-                alien.rect.y += 50
-            else:
-                alien.rect.y -= 50
     setting.fleetDir *= -1
 
 


### PR DESCRIPTION
일반 적은 좌우로 움직이면서 동시에 아래로도 내려옵니다.
그런데 현재 보스가 일반 적과 비슷하게 움직이면서 문제점을 발견하였습니다.

[
![problem](https://user-images.githubusercontent.com/37164092/38773995-2b075ae8-4097-11e8-95f1-cad7ac45c927.png)
](url)

보스가 좌-우로 움직이면서 발사되는 탄막은 자연스럽게 같이 좌-우로 움직이는 모양이 됩니다.
그래서 지그재그형 길과 비슷하게 됩니다.
그런데 이때 생기는 공간은 위로 갈수록(즉 보스와 가까워질수록) 좁아지는데,
보스가 내려오면 내려올수록 플레이어가 피할 수 있는 공간이 줄어들다가 나중에는
이동속도가 느려서 피하지 못하거나(피탄당할 경우 아이템을 잃어버립니다)
아예 기체의 피탄판정보다 탄 사이의 공간이 좁아지는(즉, 무조건 맞는) 경우까지 발생합니다.

그래서 보스가 내려오는 코드를 지웠습니다. 이제 보스는 좌-우로만 움직입니다.
이것이 너무 과도한 하향일 경우, 다음 두 가지 패턴을 제시합니다.

1. 보스가 일정 Y"까지만" 내려옵니다.
2. 1과 같지만, 대신 이 경우에는 다시 초기 위치로 되돌아가는 과정을 반복합니다.
가령 Y = 50에서 시작했다가 Y = 200에 도달하면 다시 Y = 50 -> Y = 200 -> ...
이런 식입니다.

지운 부분은 IF의 Else에 해당하는 부분(즉, Alien 이 BOSS일 때만 적용됩니다)이므로
일반 적의 움직임에 변화는 없습니다.